### PR TITLE
Hotfix home spec lobby name

### DIFF
--- a/tests/e2e/specs/home.spec.js
+++ b/tests/e2e/specs/home.spec.js
@@ -8,6 +8,7 @@ function setup() {
 }
 function assertSuccessfulJoin(gameState) {
 	expect(gameState.id).to.not.eq(null);
+	cy.url().should('include', '/lobby/');
 	cy.contains("h1", `Lobby for ${gameState.name}`);
 }
 

--- a/tests/e2e/specs/home.spec.js
+++ b/tests/e2e/specs/home.spec.js
@@ -8,7 +8,7 @@ function setup() {
 }
 function assertSuccessfulJoin(gameState) {
 	expect(gameState.id).to.not.eq(null);
-	cy.contains("h1", `Lobby for ${gameState.id}`);
+	cy.contains("h1", `Lobby for ${gameState.name}`);
 }
 
 describe("Home - Page Content", () => {


### PR DESCRIPTION
Update assertSuccessfulJoin() helper to check game name in header, and check url for '/lobby/'