### PR TITLE
fix: selected card type undefined instead of null

### DIFF
--- a/src/views/GameView.vue
+++ b/src/views/GameView.vue
@@ -284,7 +284,7 @@ export default {
 		// Interactions //
 		//////////////////
 		selectedCard() {
-			return this.selectionIndex !== null ? this.player.hand[this.selectionIndex]: null;
+			return this.selectionIndex !== null ? this.player.hand[this.selectionIndex] : null;
 		},
 		isPlayersTurn() {
 			return this.game.turn % 2 === this.game.myPNum
@@ -508,17 +508,17 @@ export default {
 			if (!this.selectedCard) return;
 
 			this.$store.dispatch('requestPlayOneOff', this.selectedCard.id)
-				.then(this.clearSelection)
+				.then(this.clearSelection())
 				.catch(this.handleError);
 		},
 		resolve() {
 			this.$store.dispatch('requestResolve')
-				.then(this.clearSelection)
+				.then(this.clearSelection())
 				.catch(this.handleError);
 		},
 		counter(twoId) {
 			this.$store.dispatch('requestCounter', twoId)
-				.then(this.clearSelection)
+				.then(this.clearSelection())
 				.catch(this.handleError);
 		},
 	},


### PR DESCRIPTION
Some of the `clearSelection()` function in .then()
are not invoked, causing selected index to remain
not null, which then causes some cards (or no
cards, depending on if the index is still valid) to
be selected, resulting in either the wrong card
is shown in the preview, or `selectedCard` is
undefined, returning the error when accessing
suit and rank