### PR TITLE
Clarify targets

### DIFF
--- a/src/components/GameView/CannotCounterDialog.vue
+++ b/src/components/GameView/CannotCounterDialog.vue
@@ -10,7 +10,8 @@
 		>
 			<v-card-title>Cannot Counter</v-card-title>
 			<v-card-text>
-				Your opponent has played the {{ oneOff.name }} as a one-off.
+				Your opponent has played the {{ oneOff.name }} as a one-off
+				<span v-if="target"> targetting your {{ target.name }}</span>
 				<div class="d-flex justify-center align-center my-8">
 					<card
 						:suit="oneOff.suit"
@@ -19,6 +20,15 @@
 					<p class="ml-8">
 						{{ oneOff.ruleText }}
 					</p>
+					<div id="target-wrapper" v-if="target">
+						<span id="target-icon-wrapper" class="d-flex justify-center align-center">
+							<v-icon id="target-icon" x-large color="red">mdi-target</v-icon>
+						</span>
+						<card
+							:suit="target.suit"
+							:rank="target.rank"
+						/>
+					</div>
 				</div>
 				You cannot Counter, because you do not have a two.
 			</v-card-text>
@@ -51,7 +61,10 @@ export default {
 		},
 		oneOff: {
 			required: true,
-		}
+		},
+		target: {
+			default: null,
+		},
 	},
 	computed: {
 		show: {
@@ -66,4 +79,17 @@ export default {
 }
 </script>
 
-<style lang="scss" scoped></style>
+<style lang="scss" scoped>
+#target-wrapper {
+	display: inline-block;
+ 	position: relative;
+
+	& #target-icon-wrapper {
+		display: block;
+		position: absolute;
+		width: 100%;
+		height: 100%;
+		z-index: 1;
+	}
+}
+</style>

--- a/src/components/GameView/CounterDialog.vue
+++ b/src/components/GameView/CounterDialog.vue
@@ -10,7 +10,9 @@
 		>
 			<v-card-title>Chance to Counter</v-card-title>
 			<v-card-text>
-				Your opponent has played the {{ oneOff.name }} as a one-off.
+				Your opponent has played the {{ oneOff.name }} as a one-off
+				<span v-if="target"> targetting your {{ target.name }}</span>
+
 				<div class="d-flex justify-center align-center my-8">
 					<card
 						:suit="oneOff.suit"
@@ -19,6 +21,15 @@
 					<p class="ml-8">
 						{{ oneOff.ruleText }}
 					</p>
+					<div id="target-wrapper" v-if="target">
+						<span id="target-icon-wrapper" class="d-flex justify-center align-center">
+							<v-icon x-large color="red">mdi-target</v-icon>
+						</span>
+						<card
+							:suit="target.suit"
+							:rank="target.rank"
+						/>
+					</div>
 				</div>
 				Would you like to play a two to counter?
 			</v-card-text>
@@ -95,6 +106,9 @@ export default {
 		oneOff: {
 			required: true,
 		},
+		target: {
+			default: null,
+		},
 		// list of card objects for available twos
 		twosInHand: {
 			required: true,
@@ -128,4 +142,14 @@ export default {
 }
 </script>
 
-<style lang="scss" scoped></style>
+<style lang="scss" scoped>
+#target-wrapper {
+	position: relative;
+	& #target-icon-wrapper {
+		position: absolute;
+		width: 100%;
+		height: 100%;
+		z-index: 1;
+	}
+}
+</style>

--- a/src/store/modules/game.js
+++ b/src/store/modules/game.js
@@ -19,6 +19,7 @@ function resetState() {
 		topCard: null,
 		secondCard: null,
 		oneOff: null,
+		oneOffTarget: null,
 		waitingForOpponentToCounter: false,
 		myTurnToCounter: false,
 		// Threes
@@ -85,6 +86,9 @@ export default {
 
 			if (Object.hasOwnProperty.call(newGame, 'oneOff')) state.oneOff = _.cloneDeep(newGame.oneOff);
 			else state.oneOff = null
+			
+			if (Object.hasOwnProperty.call(newGame, 'oneOffTarget')) state.oneOffTarget = _.cloneDeep(newGame.oneOffTarget);
+			else state.oneOffTarget = null;
 		},
 		setMyPNum(state, val) {
 			state.myPNum = val;

--- a/src/views/GameView.vue
+++ b/src/views/GameView.vue
@@ -332,6 +332,7 @@
 		<counter-dialog
 			v-model="showCounterDialog"
 			:one-off="game.oneOff"
+			:target="game.oneOffTarget"
 			:twos-in-hand="twosInHand"
 			@resolve="resolve"
 			@counter="counter($event)"

--- a/src/views/GameView.vue
+++ b/src/views/GameView.vue
@@ -339,6 +339,7 @@
 		<cannot-counter-dialog
 			v-model="showCannotCounterDialog"
 			:one-off="game.oneOff"
+			:target="game.oneOffTarget"
 			@resolve="resolve"
 		/>
 		<four-dialog

--- a/tests/e2e/specs/game/oneOffs.spec.js
+++ b/tests/e2e/specs/game/oneOffs.spec.js
@@ -510,7 +510,10 @@ describe('Play TWOS', () => {
 			cy.playTargetedOneOffOpponent(Card.TWO_OF_CLUBS, Card.JACK_OF_CLUBS, 'jack')
 
 			// player resolves
-			cy.get('[data-cy=cannot-counter-resolve]').click()
+			cy.get('#cannot-counter-dialog')
+				.should('be.visible')
+				.get('[data-cy=cannot-counter-resolve]')
+				.click()
 
 			assertGameState(1, {
 				p0Hand: [],
@@ -836,7 +839,10 @@ describe('Playing NINES', ()=>{
 			cy.playTargetedOneOffOpponent(Card.NINE_OF_CLUBS, Card.JACK_OF_CLUBS, 'jack')
 
 			// player resolves
-			cy.get('[data-cy=cannot-counter-resolve]').click();
+			cy.get('#cannot-counter-dialog')
+				.should('be.visible')
+				.get('[data-cy=cannot-counter-resolve]')
+				.click();
 
 			assertGameState(1, {
 				p0Hand: [Card.ACE_OF_DIAMONDS],


### PR DESCRIPTION
Requires back end update included in[ PR #19](https://github.com/TeasingSisyphus/cuttleV2/pull/19)
Displays target of one-off in CounterDialog & CannotCounterDialog

Updates both dialogs, GameView, & store module game.js