### PR TITLE
chore: test counter dialog should be visible

### DIFF
--- a/tests/e2e/specs/game/oneOffs.spec.js
+++ b/tests/e2e/specs/game/oneOffs.spec.js
@@ -510,7 +510,10 @@ describe('Play TWOS', () => {
 			cy.playTargetedOneOffOpponent(Card.TWO_OF_CLUBS, Card.JACK_OF_CLUBS, 'jack')
 
 			// player resolves
-			cy.get('[data-cy=cannot-counter-resolve]').click()
+			cy.get('#cannot-counter-dialog')
+				.should('be.visible')
+				.get('[data-cy=cannot-counter-resolve]')
+				.click()
 
 			assertGameState(1, {
 				p0Hand: [],
@@ -836,7 +839,10 @@ describe('Playing NINES', ()=>{
 			cy.playTargetedOneOffOpponent(Card.NINE_OF_CLUBS, Card.JACK_OF_CLUBS, 'jack')
 
 			// player resolves
-			cy.get('[data-cy=cannot-counter-resolve]').click();
+			cy.get('#cannot-counter-dialog')
+				.should('be.visible')
+				.get('[data-cy=cannot-counter-resolve]')
+				.click();
 
 			assertGameState(1, {
 				p0Hand: [Card.ACE_OF_DIAMONDS],


### PR DESCRIPTION
Was trying to see the target dialog in action, but it seems the snapshots cypress created don't show the dialog porperly. However modified these anyway for the tests to be more robust