### PR TITLE
Four dialog error handling

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -4,5 +4,6 @@
   "testFiles": [
     "out_of_game/**/*.js",
     "in_game/**/*.js"
-  ]
+  ],
+  "video": false
 }

--- a/src/components/GameView/FourDialog.vue
+++ b/src/components/GameView/FourDialog.vue
@@ -89,7 +89,8 @@ export default {
 		},
 		discard() {
 			if (this.readyToDiscard) {
-				this.$emit('discard', this.selectedIds);
+				this.$emit('discard', [...this.selectedIds]);
+				this.selectedIds = [];
 			}
 		},
 	},

--- a/tests/e2e/specs/in_game/oneOffs.spec.js
+++ b/tests/e2e/specs/in_game/oneOffs.spec.js
@@ -287,7 +287,7 @@ describe('FOURS', () => {
 			cy.get('[data-move-choice=oneOff]').click();
 	
 			assertSnackbarError('You cannot play a 4 as a one-off while your opponent has no cards in hand');
-		
+
 			assertGameState(0, {
 				p0Hand: [Card.FOUR_OF_CLUBS],
 				p0Points: [],
@@ -317,8 +317,7 @@ describe('FOURS', () => {
 
 			// Illegal Discard 1: Only 1 card selected
 			cy.log('Opponent illegally discards: No cards selected');
-			cy.discardOpponent(); // Ten of spades not in hand
-			// assertSnackbarError('You must select two cards from your hand to discard');
+			cy.discardOpponent(); // Discard with no selection
 			cy.get('#waiting-for-opponent-discard-scrim')
 				.should('be.visible');
 			assertGameState(0, {
@@ -334,8 +333,7 @@ describe('FOURS', () => {
 
 			// Illegal Discard 2: Only 1 card selected
 			cy.log('Opponent illegally discards: Chooses only 1 card');
-			cy.discardOpponent(Card.ACE_OF_HEARTS); // Ten of spades not in hand
-			// assertSnackbarError('You must select two cards from your hand to discard');
+			cy.discardOpponent(Card.ACE_OF_HEARTS); // Only 1 card selected (should have 2)
 			cy.get('#waiting-for-opponent-discard-scrim')
 				.should('be.visible');
 			assertGameState(0, {
@@ -352,7 +350,6 @@ describe('FOURS', () => {
 			// Illegal Discard 3: Card not in hand
 			cy.log('Opponent illegally discards: Chooses a card not in their hand');
 			cy.discardOpponent(Card.ACE_OF_HEARTS, Card.TEN_OF_SPADES); // Ten of spades not in hand
-			// assertSnackbarError('You must select two cards from your hand to discard');
 			cy.get('#waiting-for-opponent-discard-scrim')
 				.should('be.visible');
 			assertGameState(0, {

--- a/tests/e2e/specs/in_game/oneOffs.spec.js
+++ b/tests/e2e/specs/in_game/oneOffs.spec.js
@@ -297,13 +297,100 @@ describe('FOURS', () => {
 				p1FaceCards: [],
 			});
 		});
+
+		it('Prevents opponent from discarding illegally', () => {
+			// Set Up
+			cy.loadGameFixture({
+				p0Hand: [Card.FOUR_OF_SPADES, Card.FOUR_OF_CLUBS],
+				p0Points: [],
+				p0FaceCards: [],
+				p1Hand: [Card.ACE_OF_HEARTS, Card.ACE_OF_DIAMONDS, Card.TEN_OF_HEARTS],
+				p1Points: [],
+				p1FaceCards: [],
+			});
+			cy.get('[data-player-hand-card]').should('have.length', 2);
+			cy.log('Loaded fixture');
+
+			cy.playOneOffAndResolveAsPlayer(Card.FOUR_OF_SPADES);
+			cy.get('#waiting-for-opponent-discard-scrim')
+				.should('be.visible');
+
+			// Illegal Discard 1: Only 1 card selected
+			cy.log('Opponent illegally discards: No cards selected');
+			cy.discardOpponent(); // Ten of spades not in hand
+			// assertSnackbarError('You must select two cards from your hand to discard');
+			cy.get('#waiting-for-opponent-discard-scrim')
+				.should('be.visible');
+			assertGameState(0, {
+				p0Hand: [Card.FOUR_OF_CLUBS],
+				p0Points: [],
+				p0FaceCards: [],
+				p1Hand: [Card.ACE_OF_HEARTS, Card.ACE_OF_DIAMONDS, Card.TEN_OF_HEARTS],
+				p1Points: [],
+				p1FaceCards: [],
+				scrap: [Card.FOUR_OF_SPADES]
+			});
+			cy.log('Successfully prevented discarding with no cards selected');
+
+			// Illegal Discard 2: Only 1 card selected
+			cy.log('Opponent illegally discards: Chooses only 1 card');
+			cy.discardOpponent(Card.ACE_OF_HEARTS); // Ten of spades not in hand
+			// assertSnackbarError('You must select two cards from your hand to discard');
+			cy.get('#waiting-for-opponent-discard-scrim')
+				.should('be.visible');
+			assertGameState(0, {
+				p0Hand: [Card.FOUR_OF_CLUBS],
+				p0Points: [],
+				p0FaceCards: [],
+				p1Hand: [Card.ACE_OF_HEARTS, Card.ACE_OF_DIAMONDS, Card.TEN_OF_HEARTS],
+				p1Points: [],
+				p1FaceCards: [],
+				scrap: [Card.FOUR_OF_SPADES]
+			});
+			cy.log('Successfully prevented discarding only 1 card');
+
+			// Illegal Discard 3: Card not in hand
+			cy.log('Opponent illegally discards: Chooses a card not in their hand');
+			cy.discardOpponent(Card.ACE_OF_HEARTS, Card.TEN_OF_SPADES); // Ten of spades not in hand
+			// assertSnackbarError('You must select two cards from your hand to discard');
+			cy.get('#waiting-for-opponent-discard-scrim')
+				.should('be.visible');
+			assertGameState(0, {
+				p0Hand: [Card.FOUR_OF_CLUBS],
+				p0Points: [],
+				p0FaceCards: [],
+				p1Hand: [Card.ACE_OF_HEARTS, Card.ACE_OF_DIAMONDS, Card.TEN_OF_HEARTS],
+				p1Points: [],
+				p1FaceCards: [],
+				scrap: [Card.FOUR_OF_SPADES]
+			});
+			cy.log('Successfully prevented discarding a card not in hand');
+
+			// Legal Discard
+			cy.discardOpponent(Card.ACE_OF_HEARTS, Card.ACE_OF_DIAMONDS);
+			cy.get('#waiting-for-opponent-discard-scrim')
+				.should('not.be.visible');
+			assertGameState(0, {
+				p0Hand: [Card.FOUR_OF_CLUBS],
+				p0Points: [],
+				p0FaceCards: [],
+				p1Hand: [Card.TEN_OF_HEARTS],
+				p1Points: [],
+				p1FaceCards: [],
+				scrap: [
+					Card.FOUR_OF_SPADES,
+					Card.ACE_OF_HEARTS,
+					Card.ACE_OF_DIAMONDS,
+				],
+			});
+		});
 	});
 	
 	describe('Opponent playing FOURS', () => {
 		beforeEach(() => {
 			setupGameAsP1();
 		});
-		it.only('Discards two cards when opponent plays a four, repeated fours', () => {
+		it('Discards two cards when opponent plays a four, repeated fours', () => {
 			cy.loadGameFixture({
 				p0Hand: [Card.FOUR_OF_CLUBS, Card.FOUR_OF_DIAMONDS],
 				p0Points: [],

--- a/tests/e2e/specs/in_game/oneOffs.spec.js
+++ b/tests/e2e/specs/in_game/oneOffs.spec.js
@@ -448,10 +448,7 @@ describe('FOURS', () => {
 			// Choosing cards to discard
 			cy.log('Choosing two cards to discard');
 			cy.get('[data-cy=submit-four-dialog]')
-				.should('be.disabled') // can't prematurely submit
-				// .click({force: true}); // and if you do, still should fail
-			// Assert Snackbar error
-			// assertSnackbarError('You must select cards from your hand to discard');
+				.should('be.disabled'); // can't prematurely submit
 			// Discard dialog should still be open
 			cy.get('#four-discard-dialog')
 				.should('be.visible');

--- a/tests/e2e/specs/in_game/oneOffs.spec.js
+++ b/tests/e2e/specs/in_game/oneOffs.spec.js
@@ -308,11 +308,12 @@ describe('FOURS', () => {
 				p0Hand: [Card.FOUR_OF_CLUBS, Card.FOUR_OF_DIAMONDS],
 				p0Points: [],
 				p0FaceCards: [],
-				p1Hand: [Card.FOUR_OF_SPADES, Card.ACE_OF_DIAMONDS, Card.TEN_OF_HEARTS, Card.SIX_OF_DIAMONDS],
+				p1Hand: [Card.FOUR_OF_SPADES, Card.ACE_OF_DIAMONDS, Card.TEN_OF_HEARTS ],
 				p1Points: [],
 				p1FaceCards: [],
+				topCard: Card.SIX_OF_DIAMONDS,
 			});
-			cy.get('[data-player-hand-card]').should('have.length', 4);
+			cy.get('[data-player-hand-card]').should('have.length', 3);
 			cy.log('Loaded fixture');
 	
 			// Opponent plays four
@@ -322,7 +323,8 @@ describe('FOURS', () => {
 				.should('be.visible')
 				.get('[data-cy=cannot-counter-resolve]')
 				.click();
-	
+			cy.log('Player resolves opponent\'s Four');
+
 			// Four Dialog appears (you must discard)
 			cy.get('#four-discard-dialog')
 				.should('be.visible');
@@ -339,14 +341,15 @@ describe('FOURS', () => {
 					p0Hand: [Card.FOUR_OF_DIAMONDS],
 					p0Points: [],
 					p0FaceCards: [],
-					p1Hand: [Card.TEN_OF_HEARTS, Card.SIX_OF_DIAMONDS],
+					p1Hand: [Card.TEN_OF_HEARTS],
 					p1Points: [],
 					p1FaceCards: [],
 					scrap: [Card.FOUR_OF_CLUBS, Card.FOUR_OF_SPADES, Card.ACE_OF_DIAMONDS],
+					topCard: Card.SIX_OF_DIAMONDS,
 				}
 			);
 
-			// Player draws
+			// Player draws the 6 of diamonds
 			cy.get('#deck')
 				.click();
 			
@@ -362,22 +365,27 @@ describe('FOURS', () => {
 			cy.log('Choosing two cards to discard');
 			cy.get('[data-cy=submit-four-dialog]')
 				.should('be.disabled') // can't prematurely submit
-				.click({force: true}); // and if you do, still should fail
+				// .click({force: true}); // and if you do, still should fail
 			// Assert Snackbar error
-			assertSnackbarError('You must select cards from your hand to discard');
+			// assertSnackbarError('You must select cards from your hand to discard');
 			// Discard dialog should still be open
 			cy.get('#four-discard-dialog')
 				.should('be.visible');
 			// Validate game state same as above
 			assertGameState(1,
 				{
-					p0Hand: [Card.FOUR_OF_DIAMONDS],
+					p0Hand: [],
 					p0Points: [],
 					p0FaceCards: [],
 					p1Hand: [Card.TEN_OF_HEARTS, Card.SIX_OF_DIAMONDS],
 					p1Points: [],
 					p1FaceCards: [],
-					scrap: [Card.FOUR_OF_CLUBS, Card.FOUR_OF_SPADES, Card.ACE_OF_DIAMONDS],
+					scrap: [
+						Card.FOUR_OF_CLUBS,
+						Card.ACE_OF_DIAMONDS,
+						Card.FOUR_OF_SPADES,
+						Card.FOUR_OF_DIAMONDS
+					],
 				}
 			);
 			// Properly discard as expected
@@ -389,7 +397,7 @@ describe('FOURS', () => {
 
 			assertGameState(1,
 				{
-					p0Hand: [Card.FOUR_OF_DIAMONDS],
+					p0Hand: [],
 					p0Points: [],
 					p0FaceCards: [],
 					p1Hand: [],
@@ -400,7 +408,8 @@ describe('FOURS', () => {
 						Card.FOUR_OF_SPADES,
 						Card.ACE_OF_DIAMONDS,
 						Card.TEN_OF_HEARTS,
-						Card.SIX_OF_DIAMONDS
+						Card.SIX_OF_DIAMONDS,
+						Card.FOUR_OF_DIAMONDS
 					],
 				}
 			);

--- a/tests/e2e/support/commands.js
+++ b/tests/e2e/support/commands.js
@@ -402,7 +402,7 @@ Cypress.Commands.add('resolveOpponent', () => {
 
 /**
  * Discards 1-2 cards to resolve four
- * @param card1 {suit: number, rank: number} REQUIRED
+ * @param card1 {suit: number, rank: number} OPTIONAL
  * @param card2 {suit: number, rank: number} OPTIONAL
  */
 Cypress.Commands.add('discardOpponent', (card1, card2) => {
@@ -410,9 +410,14 @@ Cypress.Commands.add('discardOpponent', (card1, card2) => {
 		.window()
 		.its('app.$store.state.game')
 		.then((game) => {
-			const opponent = game.players[(game.myPNum + 1) % 2];
-			const cardId1 = opponent.hand.find((handCard) => cardsMatch(card1, handCard)).id;
-			const cardId2 = card2 ? opponent.hand.find((handCard) => cardsMatch(card2, handCard)).id : undefined;
+			let cardId1 = undefined;
+			let cardId2 = undefined;
+			if (card1) {
+				cardId1 = getCardIds(game, [card1])[0];
+			}
+			if (card2) {
+				cardId2 = getCardIds(game, [card2])[0];
+			}
 			io.socket.get('/game/resolveFour', {
 				cardId1,
 				cardId2,


### PR DESCRIPTION
Fixes a bug where being hit with a 4 repeatedly allowed player to skip discarding on subsequent resolutions

Added test cases to address confirm the UI can no longer be used to trigger the bug and that the backend prevents ill-formed requests in case the UI is sidestepped